### PR TITLE
Support for initial pose of first trajectory.

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -409,7 +409,6 @@ MapBuilderBridge::GetLocalTrajectoryData() {
   return local_trajectory_data;
 }
 
-extern ros::Publisher* pathpub;
 void MapBuilderBridge::HandleTrajectoryQuery(
     cartographer_ros_msgs::TrajectoryQuery::Request& request,
     cartographer_ros_msgs::TrajectoryQuery::Response& response) {
@@ -433,6 +432,8 @@ void MapBuilderBridge::HandleTrajectoryQuery(
       "Retrieved ", response.trajectory.size(),
       " trajectory nodes from trajectory ", request.trajectory_id, ".");
 }
+
+extern ros::Publisher* pathpub;
 
 visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
   visualization_msgs::MarkerArray trajectory_node_list;

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -679,14 +679,16 @@ bool Node::HandleStartTrajectory(
     }
 
     // Check if the requested trajectory for the relative initial pose exists.
-    response.status = TrajectoryStateToStatus(
-        request.relative_to_trajectory_id,
-        {TrajectoryState::ACTIVE, TrajectoryState::FROZEN,
-         TrajectoryState::FINISHED} /* valid states */);
-    if (response.status.code != cartographer_ros_msgs::StatusCode::OK) {
-      LOG(ERROR) << "Can't start a trajectory with initial pose: "
-                 << response.status.message;
-      return true;
+    if (request.relative_to_trajectory_id != -1) {
+        response.status = TrajectoryStateToStatus(
+                request.relative_to_trajectory_id,
+                {TrajectoryState::ACTIVE, TrajectoryState::FROZEN,
+                 TrajectoryState::FINISHED} /* valid states */);
+        if (response.status.code != cartographer_ros_msgs::StatusCode::OK) {
+            LOG(ERROR) << "Can't start a trajectory with initial pose: "
+                       << response.status.message;
+            return true;
+        }
     }
 
     ::cartographer::mapping::proto::InitialTrajectoryPose

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -679,6 +679,8 @@ bool Node::HandleStartTrajectory(
     }
 
     // Check if the requested trajectory for the relative initial pose exists.
+    // No need to check for existence of virtual trajectory -1,
+    // which is fixed in the map origin frame
     if (request.relative_to_trajectory_id != -1) {
         response.status = TrajectoryStateToStatus(
                 request.relative_to_trajectory_id,

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -158,13 +158,13 @@ class Node {
 
   // Returns the set of SensorIds expected for a trajectory.
   // 'SensorId::id' is the expected ROS topic name.
+  std::set<::cartographer::mapping::TrajectoryBuilderInterface::SensorId>
+  ComputeExpectedSensorIds(const TrajectoryOptions& options) const;
   bool HandleSubmapCloudQuery(
       cartographer_ros_msgs::SubmapCloudQuery::Request& request,
       cartographer_ros_msgs::SubmapCloudQuery::Response& response);
 
   void PublishSubmapPointCloud(const ::ros::WallTimerEvent& timer_event);
-  std::set<::cartographer::mapping::TrajectoryBuilderInterface::SensorId>
-    ComputeExpectedSensorIds(const TrajectoryOptions& options) const;
   int AddTrajectory(const TrajectoryOptions& options);
   void LaunchSubscribers(const TrajectoryOptions& options, int trajectory_id);
   void PublishSubmapList(const ::ros::WallTimerEvent& timer_event);


### PR DESCRIPTION
Allow the user to specify a trajectories relative pose with respect to the
origin by passing -1 as the trajectory_id.
